### PR TITLE
Fix crash when command not found (with some compilers)

### DIFF
--- a/source/consoleCommands.h
+++ b/source/consoleCommands.h
@@ -31,7 +31,7 @@ typedef struct sConsoleCommandStruct
 #endif // CONSOLE_COMMAND_MAX_HELP_LENGTH 
 } sConsoleCommandTable_T;
 
-#define CONSOLE_COMMAND_TABLE_END {"",NULL, HELP("")}
+#define CONSOLE_COMMAND_TABLE_END {NULL, NULL, HELP("")}
 
 const sConsoleCommandTable_T* ConsoleCommandsGetTable(void);
 


### PR DESCRIPTION
There's a special command in the command table which indicates the end of the table.  This command is initialized with name set to an empty string, but elsewhere the code in ConsoleProcess() actually tests if name == NULL, which is never true, so the code overruns the command table and tests uninitialized memory.  When I compile for STM with SystemWorkbench it works because (apparently?) memory happens to be inited to 0 beyond the end of the command table, so when .name is tested there it does turn out to be NULL and the loop ends.  But when I compile with PlatformIO, memory beyond the table is not initialized so it tries to actually dereference a wild pointer and faults.

This fix sets the name of the special end-of-table command to NULL rather than an empty string, which matches the expectations of the rest of the code.