### PR TITLE
Fixed [-Wdiscarded-qualifiers] warning for GCC.

### DIFF
--- a/source/consoleCommands.h
+++ b/source/consoleCommands.h
@@ -22,7 +22,7 @@ typedef eCommandResult_T(*ConsoleCommand_T)(const char buffer[]);
 
 typedef struct sConsoleCommandStruct
 {
-    char* name;
+    const char* name;
     ConsoleCommand_T execute;
 #if CONSOLE_COMMAND_MAX_HELP_LENGTH > 0
 	char help[CONSOLE_COMMAND_MAX_HELP_LENGTH];


### PR DESCRIPTION
GCC warning: Initialization discards 'const' qualifier from pointer target type has been fixed in the current fork. First time contributing to a GitHub repo, so please excuse any mistakes made. 