### PR TITLE
ConsoleSendString and ConsoleSendLine

### DIFF
--- a/source/console.c
+++ b/source/console.c
@@ -443,3 +443,24 @@ static eCommandResult_T ConsoleUtilsIntToHexChar(uint8_t intVal, char* pChar)
 
     return result;
 }
+// ConsoleSendString
+// Send a null terminated string to the console.
+// This is a light wrapper around ConsoleIoSendString. It uses the same
+// API convention as the rest of the top level ConsoleSendX APIs 
+// while exposing this functionality at the top level so 
+// that the lower level consoleIo module doesn't need to be
+// a dependency.
+eCommandResult_T ConsoleSendString(const char *buffer)
+{
+	ConsoleIoSendString(buffer);
+	return COMMAND_SUCCESS;
+}
+
+// ConsoleSendLine
+// Send a null terminated string to the console followed by a line ending.
+eCommandResult_T ConsoleSendLine(const char *buffer)
+{
+	ConsoleIoSendString(buffer);
+	ConsoleIoSendString(STR_ENDLINE);
+	return COMMAND_SUCCESS;
+}

--- a/source/console.h
+++ b/source/console.h
@@ -34,5 +34,7 @@ eCommandResult_T ConsoleSendParamInt32(int32_t parameterInt);
 eCommandResult_T ConsoleReceiveParamHexUint16(const char * buffer, const uint8_t parameterNumber, uint16_t* parameterUint16);
 eCommandResult_T ConsoleSendParamHexUint16(uint16_t parameterUint16);
 eCommandResult_T ConsoleSendParamHexUint8(uint8_t parameterUint8);
+eCommandResult_T ConsoleSendString(const char *buffer); // must be null terminated
+eCommandResult_T ConsoleSendLine(const char *buffer); // must be null terminated
 
 #endif // CONSOLE_H


### PR DESCRIPTION
This is a light wrapper around ConsoleIoSendString. It uses the same
API convention as the rest of the top level ConsoleSendX APIs
while exposing this functionality at the top level so
that the lower level consoleIo module doesn't need to be
a dependency.

I also add ConsoleSendLine that also sends a STR_ENDLINE afterward (similar to printLn() in other frameworks).